### PR TITLE
Common colors

### DIFF
--- a/Swollball/Upgrades/Armor.cs
+++ b/Swollball/Upgrades/Armor.cs
@@ -14,8 +14,7 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Armor+{this.UpgradeAmount}";
-        public override int BorderColor => 11184810; // AAAAAA
-        public override int FillColor => 15724527; // EFEFEF
+        public override int BorderColor => UpgradeColors.GREEN;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/BaseUpgrade.cs
+++ b/Swollball/Upgrades/BaseUpgrade.cs
@@ -16,7 +16,7 @@ namespace Swollball.Upgrades
 
         public abstract int BorderColor { get; }
 
-        public abstract int FillColor { get; }
+        public virtual int FillColor { get; } = UpgradeColors.WHITE;
 
         public int Cost { get; }
 

--- a/Swollball/Upgrades/BlankUpgrade.cs
+++ b/Swollball/Upgrades/BlankUpgrade.cs
@@ -17,7 +17,7 @@ namespace Swollball.Upgrades
         public string ServerId { get; private set; } = Guid.NewGuid().ToString();
 
         public int BorderColor { get; private set; } = 0;
-        public int FillColor => 16777215;
+        public int FillColor => UpgradeColors.WHITE;
 
         public int UpgradeAmount => 0;
 

--- a/Swollball/Upgrades/Compounding/ArmorPerArmor.cs
+++ b/Swollball/Upgrades/Compounding/ArmorPerArmor.cs
@@ -13,8 +13,8 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Armor+{this.UpgradeAmount} for every 10 armor you have.";
-        public override int BorderColor => 11184827; // AAAABB
-        public override int FillColor => 15527916; // ECEFEC
+        public override int BorderColor => UpgradeColors.GREEN;
+        public override int FillColor => UpgradeColors.LAVENDER;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Compounding/HpPerDamageTaken.cs
+++ b/Swollball/Upgrades/Compounding/HpPerDamageTaken.cs
@@ -13,8 +13,8 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"HP+{this.UpgradeAmount} for every 10 damage taken last round.";
-        public override int BorderColor => 1157887; // 11AAFF
-        public override int FillColor => 11193565; // AACCDD
+        public override int BorderColor => UpgradeColors.RED;
+        public override int FillColor => UpgradeColors.LAVENDER;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Compounding/HpPerSize.cs
+++ b/Swollball/Upgrades/Compounding/HpPerSize.cs
@@ -13,8 +13,8 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"HP+{this.UpgradeAmount} for every 10 size you have.";
-        public override int BorderColor => 1162239; // 11BBFF
-        public override int FillColor => 12434943; // BDBDFF;
+        public override int BorderColor => UpgradeColors.RED;
+        public override int FillColor => UpgradeColors.LAVENDER;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Compounding/HpPerSpeed.cs
+++ b/Swollball/Upgrades/Compounding/HpPerSpeed.cs
@@ -13,8 +13,8 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"HP+{this.UpgradeAmount} for every 10 speed you have.";
-        public override int BorderColor => 3342387; // 330033
-        public override int FillColor => 15597806; // EE00EE;
+        public override int BorderColor => UpgradeColors.RED;
+        public override int FillColor => UpgradeColors.LAVENDER;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Compounding/SizePerSize.cs
+++ b/Swollball/Upgrades/Compounding/SizePerSize.cs
@@ -13,8 +13,8 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Size+{this.UpgradeAmount} for every 10 size you have";
-        public override int BorderColor => 48110; // 00BBEE
-        public override int FillColor => 11189950; // AABEBE
+        public override int BorderColor => UpgradeColors.PURPLE;
+        public override int FillColor => UpgradeColors.LAVENDER;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Compounding/SpeedPerSize.cs
+++ b/Swollball/Upgrades/Compounding/SpeedPerSize.cs
@@ -13,8 +13,8 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Speed+{this.UpgradeAmount} for every 10 size you have.";
-        public override int BorderColor => 2228258; // 220022
-        public override int FillColor => 16711935; // FF00FF;
+        public override int BorderColor => UpgradeColors.BLUE;
+        public override int FillColor => UpgradeColors.LAVENDER;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Damage.cs
+++ b/Swollball/Upgrades/Damage.cs
@@ -14,8 +14,7 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Damage+{this.UpgradeAmount}";
-        public override int BorderColor => 16716066; // FF1122
-        public override int FillColor => 12303291; // BBBBBB
+        public override int BorderColor => UpgradeColors.BROWN;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Hp.cs
+++ b/Swollball/Upgrades/Hp.cs
@@ -14,8 +14,7 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"HP+{this.UpgradeAmount}";
-        public override int BorderColor => 1179392; // 11FF00
-        public override int FillColor => 14540253; // DDDDDD
+        public override int BorderColor => UpgradeColors.RED;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/ArmorWhenHit.cs
+++ b/Swollball/Upgrades/Persistent/ArmorWhenHit.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Gain {this.UpgradeAmount} armor for the round when you get hit";
 
-        public override int BorderColor => 16755370; // FFAAAA
-        public override int FillColor => 11206655; // AAFFFF
+        public override int BorderColor => UpgradeColors.GREEN;
+        public override int FillColor => UpgradeColors.SKYBLUE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/ArmorWhenHp.cs
+++ b/Swollball/Upgrades/Persistent/ArmorWhenHp.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Armor+{this.UpgradeAmount} whenever you gain 10 HP.";
 
-        public override int BorderColor => 14527197; // DDAADD
-        public override int FillColor => 14483507; // DD0033
+        public override int BorderColor => UpgradeColors.GREEN;
+        public override int FillColor => UpgradeColors.ROSE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/CreditWhenHp.cs
+++ b/Swollball/Upgrades/Persistent/CreditWhenHp.cs
@@ -14,10 +14,10 @@ namespace Swollball.Upgrades
             this.Tags.Add(UpgradeTags.CASHUPGRADE);
         }
 
-        public override string Description => $"Gain {this.UpgradeAmount} credit when you gain HP.";
+        public override string Description => $"Gain {this.UpgradeAmount} credits when you gain HP.";
 
-        public override int BorderColor => 43775; // 00AAFF
-        public override int FillColor => 11259375; // ABCDEF
+        public override int BorderColor => UpgradeColors.BLACK;
+        public override int FillColor => UpgradeColors.PERIWINKLE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/CreditsWhenDamageDone.cs
+++ b/Swollball/Upgrades/Persistent/CreditsWhenDamageDone.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Gain {this.UpgradeAmount} credits per round for every 100 damage done.";
 
-        public override int BorderColor => 15662848; // EEFF00
-        public override int FillColor => 12237498; // BABABA
+        public override int BorderColor => UpgradeColors.BLACK;
+        public override int FillColor => UpgradeColors.PERIWINKLE;
 
         public override void StartNextRound(Player player)
         {

--- a/Swollball/Upgrades/Persistent/DamageWhenArmor.cs
+++ b/Swollball/Upgrades/Persistent/DamageWhenArmor.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Damage+{this.UpgradeAmount} every armor gained.";
 
-        public override int BorderColor => 16759756; // FFBBCC
-        public override int FillColor => 15395562; // EAEAEA
+        public override int BorderColor => UpgradeColors.BROWN;
+        public override int FillColor => UpgradeColors.ROSE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/DamageWhenSpeed.cs
+++ b/Swollball/Upgrades/Persistent/DamageWhenSpeed.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Damage+{this.UpgradeAmount} for every 10 speed gained";
 
-        public override int BorderColor => 10092288; // 99FF00
-        public override int FillColor => 11250603; // ABABAB
+        public override int BorderColor => UpgradeColors.BROWN;
+        public override int FillColor => UpgradeColors.SKYBLUE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/HpWhenDamageDone.cs
+++ b/Swollball/Upgrades/Persistent/HpWhenDamageDone.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Regain {this.UpgradeAmount} HP for every 10 damage dealt.";
 
-        public override int BorderColor => 16711748; // FF0044
-        public override int FillColor => 12369084; // BCBCBC
+        public override int BorderColor => UpgradeColors.RED;
+        public override int FillColor => UpgradeColors.SKYBLUE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Persistent/SizeWhenHp.cs
+++ b/Swollball/Upgrades/Persistent/SizeWhenHp.cs
@@ -16,8 +16,8 @@ namespace Swollball.Upgrades
 
         public override string Description => $"Size+{this.UpgradeAmount} every 10 hp gained";
 
-        public override int BorderColor => 43775; // 00AAFF
-        public override int FillColor => 11259375; // ABCDEF
+        public override int BorderColor => UpgradeColors.PURPLE;
+        public override int FillColor => UpgradeColors.ROSE;
 
         public override void AfterUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Size.cs
+++ b/Swollball/Upgrades/Size.cs
@@ -14,8 +14,7 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Size+{this.UpgradeAmount}";
-        public override int BorderColor => 8959; // 0022FF
-        public override int FillColor => 13421772; // CCCCCC
+        public override int BorderColor => UpgradeColors.PURPLE;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/Speed.cs
+++ b/Swollball/Upgrades/Speed.cs
@@ -14,8 +14,7 @@ namespace Swollball.Upgrades
         }
 
         public override string Description => $"Speed+{this.UpgradeAmount}";
-        public override int BorderColor => 2293504; // 22FF00
-        public override int FillColor => 15658734; // EEEEEE;
+        public override int BorderColor => UpgradeColors.BLUE;
 
         public override void PerformUpgrade(Player player)
         {

--- a/Swollball/Upgrades/UpgradeFactory.cs
+++ b/Swollball/Upgrades/UpgradeFactory.cs
@@ -104,7 +104,7 @@ namespace Swollball.Upgrades
             Tuple.Create(4, () => new SizePerSize(4, 8, Names.GET_SWOLL) as IUpgrade),
             Tuple.Create(4, () => new HpWhenDamageDone(8, 9, Names.Siphon, 4) as IUpgrade),
             Tuple.Create(3, () => new ArmorWhenHit(8, 10, Names.Fortify, 2) as IUpgrade),
-            Tuple.Create(3, () => new CreditWhenHp(1, 10, Names.Modelling, 5) as IUpgrade),
+            Tuple.Create(3, () => new CreditWhenHp(1, 10, Names.Modelling, 3) as IUpgrade),
         };
         
         private static Lazy<Func<IUpgrade>[]> Tier1Upgrades = new Lazy<Func<IUpgrade>[]>(() =>

--- a/Swollball/Upgrades/UpgradeTags.cs
+++ b/Swollball/Upgrades/UpgradeTags.cs
@@ -6,7 +6,9 @@ using System.Threading.Tasks;
 
 namespace Swollball.Upgrades
 {
-    // Tags that the client needs to know about
+    /// <summary>
+    /// Tags that the client needs to know about
+    /// </summary>
     public static class UpgradeTags
     {
         // For tags that the client needs to implement logic for
@@ -27,5 +29,30 @@ namespace Swollball.Upgrades
         public const string SIZEUPGRADE = "SizeUpg";
         public const string HPUPGRADE = "HpUpg";
         public const string CASHUPGRADE = "CashUpg";
+    }
+
+    /// <summary>
+    /// Colors for cards
+    /// </summary>
+    public static class UpgradeColors
+    {
+        // Dark colors for borders
+        public const int BLACK = 0;
+        public const int RED = 660808; // 0x660808
+        public const int BROWN = 5712390; // 0x572A06
+        public const int GREEN = 21530; // 0x00541A
+        public const int BLUE = 802393; // 0x0C3E59
+        public const int PURPLE = 2690117; // 0x290C45
+
+        // Light colors for background
+        public const int ROSE = 15584203; // 0xEDCBCB
+        public const int LAVENDER = 14599890; // 0xDEC6D2
+        public const int PERIWINKLE = 14014199; // 0xD5D6F7
+        public const int SKYBLUE = 14873335; // 0xE2F2F7
+        public const int AQUA = 14678006; // 0xDFF7F6
+        public const int LIGHTGREEN = 15794158; // 0xF0FFEE
+        public const int LIME = 16383963; // 0xF9FFDB
+        public const int LIGHTGRAY = 12763842; // 0xC2C2C2
+        public const int WHITE = 16777215; // 0xFFFFFF
     }
 }

--- a/scripts/Swollball_Player_App.ts
+++ b/scripts/Swollball_Player_App.ts
@@ -446,7 +446,7 @@ class UpgradeCard extends Phaser.Physics.Arcade.Sprite {
             if (upgradeData.Duration > 0) {
                 durationTag = upgradeData.Duration.toString();
             }
-            this.Tags = scene.add.text(x + this.width * 0.001, y + this.height * 0.9, "[" + durationTag + "]", { color: 'Black', align: 'Center' });
+            this.Tags = scene.add.text(x + this.width * 0.001, y + this.height * 0.86, "[" + durationTag + "]", { color: 'Black', align: 'Center' });
             this.Tags.scale = width * 0.005;
         }
     }
@@ -720,6 +720,13 @@ function DrawUpgradeCardBorder(card: UpgradeCard, graphics: Phaser.GameObjects.G
         graphics.fillCircle(xPos, card.Cost.y + card.Cost.scale * 8, card.Cost.scale * 12);
         graphics.lineStyle(lineWidth * 0.3, 0x222222);
         graphics.strokeCircle(xPos, card.Cost.y + card.Cost.scale * 8, card.Cost.scale * 12);
+    }
+
+    if (card.Tags != undefined) {
+        graphics.fillStyle(0x0DE0E0);
+        graphics.fillRect(card.Tags.x, card.Tags.y, card.Tags.displayWidth, card.Tags.displayHeight);
+        graphics.lineStyle(lineWidth * 0.3, 0x222222);
+        graphics.strokeRect(card.Tags.x, card.Tags.y, card.Tags.displayWidth, card.Tags.displayHeight);
     }
 }
 


### PR DESCRIPTION
Cards use a common set of colors. Borders represent the primary stat being increased, fill color represents the kind of card.

Also add a border around the display for duration, making it more readable.