### PR TITLE
Have Player class extend Sprite

### DIFF
--- a/scripts/Zombbomb/Zombbomb_Lobby_App.ts
+++ b/scripts/Zombbomb/Zombbomb_Lobby_App.ts
@@ -96,7 +96,9 @@ class ZombbombArena extends Phaser.Scene {
                 case "Arena":
                     var player = body1 as Player;
                     player.zombiesInContact++;
-                    //body1.destroy();
+
+                    // TODO: Destroy the player on contact for now
+                    body1.destroy();
                     break;
                 case "SettingUp":
                 default:


### PR DESCRIPTION
Have Player class extend Sprite

This allows for collision events to modify Player properties - and currently this is being used to keep track of how many zombies are in contact with the player.