### PR TITLE
Synchronize player controller client

### DIFF
--- a/Zombbomb/GameHub/GameHub.Zombie.cs
+++ b/Zombbomb/GameHub/GameHub.Zombie.cs
@@ -69,9 +69,6 @@ namespace Zombbomb
             (var zombie, var room) = await this.FindPlayerAndRoom(zombieId, roomId);
             if (zombie == null || room == null) { return; }
 
-            // No updates necessary if the zombie is dead
-            if (zombie.IsDead) { return; }
-
             zombie.LocationX = x;
             zombie.LocationY = y;
 

--- a/scripts/Zombbomb/Zombbomb_Player_App.ts
+++ b/scripts/Zombbomb/Zombbomb_Player_App.ts
@@ -41,8 +41,10 @@ var TOPBOUND: number;
 var BOTTOMBOUND: number;
 var ZOMBIESPEED: number;
 var RESPAWNTIME: number;
+var READYFORCONTROL: boolean = false; // This boolean means that the server and client have synchronized and control is ready
 
 function startRespawnTimer(game: Phaser.Game) {
+    READYFORCONTROL = false;
     var activeScene = game.scene.getScene("ZombieControl");
     var nextScene = game.scene.getScene("RespawnControl");
     activeScene.scene.switch("RespawnControl");
@@ -126,6 +128,8 @@ class ZombieControl extends Phaser.Scene {
     }
 
     update() {
+        if (!READYFORCONTROL) return; // Abort if state is not synchronized
+
         var deltaTime = this.time.now - this.lastUpdateTime;
 
         // If deltatime is somehow lagging, don't bother with any input

--- a/wwwroot/Zombbomb/gameplayer.js
+++ b/wwwroot/Zombbomb/gameplayer.js
@@ -41,6 +41,7 @@ connection.on("BeZombie", function (zombieId, roomId, leftBoundIn, rightBoundIn,
 connection.on("SetPosition", function (x, y) {
     XLOC = x;
     YLOC = y;
+    READYFORCONTROL = true; // Only after receiving 'SetPosition' is state synchronized
 });
 
 connection.on("SetBounds", function (leftBoundIn, rightBoundIn, topBoundIn, bottomBoundIn) {


### PR DESCRIPTION
Synchronize player controller client so that updates don't get sent from player to server until the player is synchronized.

This is to solve the issue where the player was updating the server's position based on its old position, when a player was respawning, before the server updated the client's respawned position.